### PR TITLE
Unable to pass tests - timestamp - event - errormessage

### DIFF
--- a/pallets/kleroterion/src/lib.rs
+++ b/pallets/kleroterion/src/lib.rs
@@ -93,6 +93,8 @@ pub mod pallet {
 	// Errors inform users that something went wrong.
 	#[pallet::error]
 	pub enum Error<T> {
+		/// Invalid Signer
+		BadOrigin,
 		/// Arithemtic overflow when incrementing the Jury Call counter.
 		JuryCallCntOverflow,
 		/// Cannot use tTwo identical tribe names.
@@ -110,6 +112,7 @@ pub mod pallet {
 	impl<T: Config> Printable for Error<T> {
 		fn print(&self) {
 		  match self {
+			Error::BadOrigin => "BadOrigin".print(),  
 			Error::JuryCallCntOverflow => "Jury Call Value Overflowed".print(),
 			Error::DuplicateTribes => "Duplicate tribe names entered".print(),
 			Error::ZeroSelections => "Zero selections not allowed".print(),
@@ -143,6 +146,8 @@ pub mod pallet {
 
 			// Check that timestamp is in the future compared to current blocks timestamp
 			let time_now: u64 = T::TimeProvider::now().as_secs();
+			print(time_now);
+			print(start_after);
 			if time_now >= start_after {
 				print(Error::<T>::StartAfterInThePast);
 				Err(Error::<T>::StartAfterInThePast)? 


### PR DESCRIPTION
Hello team.
My first version of the Open Jury Call is mostly complete. The Jury Call storage would still need some hash map table to store the candidates, but before doing that I had tried to learn how to run tests correctly and lost a lot of time without reaching the objective.

I have discovered that when one uses the pallet_timestamp, he has to setup the tests so that the timestamp is set in the 1st mock block. I managed to do that but still am unable to correctly pass the test for entering a start_after parameter in the future. I think the code is correct in the function but the test setup needs more tweaking.

For Events also I am having problems. Again I found examples on how to test for event, but I was not able to run the test correctly. Here the problem is that the Error defined in the test/mock files does not match the type returned by the call to OpenJuryCall. 


Also , I had troubles matching Errors in the tests and in the pallet.
 It looks like this when I try to match the error for a missing signer:

---- tests::it_fails_with_no_origin stdout ----
thread 'tests::it_fails_with_no_origin' panicked at 'assertion failed: `(left == right)`
  left: `Err(BadOrigin)`,
 right: `Err(Module { index: 2, error: 0, message: Some("BadOrigin") })`', pallets/kleroterion/src/tests.rs:36:9

